### PR TITLE
Add support for editing a module identifiable by its module code

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ModuleEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleEditCommand.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_NAME;
+
+import java.util.Optional;
+
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleManager;
+
+/**
+ * Edits the details of an existing module in Trajectory
+ */
+public class ModuleEditCommand extends Command {
+
+    public static final String COMMAND_WORD = "module edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the module identified "
+            + "by its module code. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_MODULE_CODE + "MODULE_CODE "
+            + "[" + PREFIX_MODULE_NAME + "MODULE_NAME]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_MODULE_CODE + "CS2113 "
+            + PREFIX_MODULE_NAME + "SE & OOP";
+
+    public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This module already exists in Trajectory.";
+
+    private final String moduleCode;
+    private final EditModuleDescriptor editModuleDescriptor;
+
+    public ModuleEditCommand(String moduleCode, EditModuleDescriptor editModuleDescriptor) {
+        requireNonNull(editModuleDescriptor);
+
+        this.moduleCode = moduleCode;
+        this.editModuleDescriptor = new EditModuleDescriptor(editModuleDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        ModuleManager moduleManager = new ModuleManager();
+        Module moduleToEdit = moduleManager.getModuleByModuleCode(moduleCode);
+        Module editedModule = createEditedModule(moduleToEdit, editModuleDescriptor);
+
+        moduleManager.updateModule(moduleToEdit, editedModule);
+        moduleManager.saveModuleList();
+
+        return new CommandResult(String.format(MESSAGE_EDIT_MODULE_SUCCESS, moduleToEdit));
+    }
+
+    /**
+     * Creates and returns a {@code Module} with the details of {@code moduleToEdit}
+     * edited with {@code editModuleDescriptor}.
+     */
+    private static Module createEditedModule(Module moduleToEdit, EditModuleDescriptor editModuleDescriptor) {
+        assert moduleToEdit != null;
+
+        String moduleCode = moduleToEdit.getModuleCode();
+        String moduleName = editModuleDescriptor.getModuleName().orElse(moduleToEdit.getModuleName());
+
+        return new Module(moduleCode, moduleName);
+    }
+
+    /**
+     * Stores the details to edit the module with. Each non-empty field value (other than the module code)
+     * will replace the corresponding field value of the module.
+     */
+    public static class EditModuleDescriptor {
+        private String moduleCode;
+        private String moduleName;
+
+        public EditModuleDescriptor() { }
+
+        /**
+         * Copy constructor
+         */
+        public EditModuleDescriptor(EditModuleDescriptor toCopy) {
+            setModuleCode(toCopy.moduleCode);
+            setModuleName(toCopy.moduleName);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(moduleName);
+        }
+
+        public Optional<String> getModuleCode() {
+            return Optional.ofNullable(moduleCode);
+        }
+
+        public void setModuleCode(String moduleCode) {
+            this.moduleCode = moduleCode;
+        }
+
+        public Optional<String> getModuleName() {
+            return Optional.ofNullable(moduleName);
+        }
+
+        public void setModuleName(String moduleName) {
+            this.moduleName = moduleName;
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ModuleListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleListCommand.java
@@ -30,7 +30,7 @@ public class ModuleListCommand extends Command {
         }
 
         return new CommandResult(
-                String.format(MESSAGE_SUCCESS, StorageController.getModuleStorage().size(), "s")
+                String.format(MESSAGE_SUCCESS, StorageController.getModuleStorage().size())
                 + "\n" + sb.toString());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ModuleAddCommand;
+import seedu.address.logic.commands.ModuleEditCommand;
 import seedu.address.logic.commands.ModuleListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
@@ -108,6 +109,9 @@ public class AddressBookParser {
 
         case ModuleAddCommand.COMMAND_WORD:
             return new ModuleAddCommandParser().parse(arguments);
+
+        case ModuleEditCommand.COMMAND_WORD:
+            return new ModuleEditCommandParser().parse(arguments);
 
         case ModuleListCommand.COMMAND_WORD:
             return new ModuleListCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -20,12 +20,18 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_COURSENAME = new Prefix("n/");
     public static final Prefix PREFIX_FACULTY = new Prefix("f/");
-    public static final Prefix PREFIX_MODULE_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_MODULE_CODE = new Prefix("c/");
     public static final Prefix PREFIX_CLASSNAME = new Prefix("c/");
     public static final Prefix PREFIX_MODULECODE = new Prefix("m/");
     public static final Prefix PREFIX_MAXENROLLMENT = new Prefix("e/");
 
     public static final Prefix PREFIX_NOTETEXT = new Prefix("t/");
 
+    /* TODO: Reorder the prefixes above in alphabetical order using the following template */
+    /* Class prefixes */
+    /* Course prefixes */
+    /* Gradebook prefixes */
+    /* Module prefixes */
+    public static final Prefix PREFIX_MODULE_CODE = new Prefix("c/");
+    public static final Prefix PREFIX_MODULE_NAME = new Prefix("n/");
+    /* Note prefixes */
 }

--- a/src/main/java/seedu/address/logic/parser/ModuleAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleAddCommandParser.java
@@ -21,8 +21,7 @@ public class ModuleAddCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ModuleAddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_MODULE_NAME, PREFIX_MODULE_CODE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE_NAME, PREFIX_MODULE_CODE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_MODULE_NAME, PREFIX_MODULE_CODE)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ModuleEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleEditCommandParser.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ModuleEditCommand;
+import seedu.address.logic.commands.ModuleEditCommand.EditModuleDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
+public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ModuleEditCommand
+     * and returns an ModuleEditCommand object for execution.
+     * @param args represents the new module details from the user's input
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    @Override
+    public ModuleEditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE_CODE, PREFIX_MODULE_NAME);
+
+        String moduleCode;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULE_CODE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleEditCommand.MESSAGE_USAGE));
+        }
+
+        moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
+
+        EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
+        editModuleDescriptor.setModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+        if (argMultimap.getValue(PREFIX_MODULE_NAME).isPresent()) {
+            editModuleDescriptor.setModuleName(argMultimap.getValue(PREFIX_MODULE_NAME).get());
+        }
+
+        if (!editModuleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(ModuleEditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new ModuleEditCommand(moduleCode, editModuleDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -4,6 +4,7 @@ package seedu.address.model.module;
  * Represents a module in Trajectory
  */
 public class Module {
+    private static final String MODULE_CODE_VALIDATION_REGEX = "^[A-Z]{2,3}[1-9]{1}[0-9]{3}[A-Z]{0,1}$";
     private String name;
     private String code;
 
@@ -18,5 +19,28 @@ public class Module {
 
     public String getModuleCode() {
         return this.code;
+    }
+
+    /**
+     * Returns true if both modules have the same module code and name.
+     */
+    public boolean isSameModule(Module otherModule) {
+        if (otherModule == this) {
+            return true;
+        }
+
+        return otherModule != null
+                && otherModule.getModuleCode().equals(getModuleCode())
+                && otherModule.getModuleName().equals(getModuleName());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Module Code: ")
+                .append(getModuleCode())
+                .append(" Module Name: ")
+                .append(getModuleName());
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/module/ModuleManager.java
+++ b/src/main/java/seedu/address/model/module/ModuleManager.java
@@ -1,5 +1,7 @@
 package seedu.address.model.module;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -25,6 +27,18 @@ public class ModuleManager {
     }
 
     /**
+     * Replaces the given module {@code target} with {@code editedModule}
+     * {@code target} must already exist in Trajectory
+     */
+    public void updateModule(Module target, Module editedModule) {
+        requireAllNonNull(target, editedModule);
+
+        int targetIndex = modules.indexOf(target);
+
+        modules.set(targetIndex, editedModule);
+    }
+
+    /**
      * Gets the module list from storage and converts it to a Module array list
      */
     private void readModuleList() {
@@ -42,6 +56,13 @@ public class ModuleManager {
                 modules.stream().map(XmlAdaptedModule::new).collect(Collectors.toCollection(ArrayList::new));
         StorageController.setModuleStorage(xmlAdaptedModules);
         StorageController.storeData();
+    }
+
+    public Module getModuleByModuleCode(String moduleCode) {
+        return this.modules.stream()
+                .filter(module -> module.getModuleCode().equals(moduleCode))
+                .findAny()
+                .orElse(null);
     }
 
     public ArrayList<Module> getModules() {


### PR DESCRIPTION
Resolves #75 

Also added a template for ordering the prefixes in lexicographical order in `CliSyntax` for team members to follow.