### PR TITLE
Implemented validation on user input when using module-related commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ModuleEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleEditCommand.java
@@ -11,7 +11,9 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleManager;
+import seedu.address.model.module.ModuleName;
 
 /**
  * Edits the details of an existing module in Trajectory
@@ -32,7 +34,8 @@ public class ModuleEditCommand extends Command {
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This module already exists in Trajectory.";
+    public static final String MESSAGE_MODULE_NOT_FOUND = "Module with code %s doesn't exist in Trajectory!";
+    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in Trajectory.";
 
     private final String moduleCode;
     private final EditModuleDescriptor editModuleDescriptor;
@@ -50,6 +53,9 @@ public class ModuleEditCommand extends Command {
 
         ModuleManager moduleManager = new ModuleManager();
         Module moduleToEdit = moduleManager.getModuleByModuleCode(moduleCode);
+        if (moduleToEdit == null) {
+            throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, moduleCode));
+        }
         Module editedModule = createEditedModule(moduleToEdit, editModuleDescriptor);
 
         moduleManager.updateModule(moduleToEdit, editedModule);
@@ -65,8 +71,8 @@ public class ModuleEditCommand extends Command {
     private static Module createEditedModule(Module moduleToEdit, EditModuleDescriptor editModuleDescriptor) {
         assert moduleToEdit != null;
 
-        String moduleCode = moduleToEdit.getModuleCode();
-        String moduleName = editModuleDescriptor.getModuleName().orElse(moduleToEdit.getModuleName());
+        ModuleCode moduleCode = moduleToEdit.getModuleCode();
+        ModuleName moduleName = editModuleDescriptor.getModuleName().orElse(moduleToEdit.getModuleName());
 
         return new Module(moduleCode, moduleName);
     }
@@ -76,8 +82,8 @@ public class ModuleEditCommand extends Command {
      * will replace the corresponding field value of the module.
      */
     public static class EditModuleDescriptor {
-        private String moduleCode;
-        private String moduleName;
+        private ModuleCode moduleCode;
+        private ModuleName moduleName;
 
         public EditModuleDescriptor() { }
 
@@ -96,19 +102,19 @@ public class ModuleEditCommand extends Command {
             return CollectionUtil.isAnyNonNull(moduleName);
         }
 
-        public Optional<String> getModuleCode() {
+        public Optional<ModuleCode> getModuleCode() {
             return Optional.ofNullable(moduleCode);
         }
 
-        public void setModuleCode(String moduleCode) {
+        public void setModuleCode(ModuleCode moduleCode) {
             this.moduleCode = moduleCode;
         }
 
-        public Optional<String> getModuleName() {
+        public Optional<ModuleName> getModuleName() {
             return Optional.ofNullable(moduleName);
         }
 
-        public void setModuleName(String moduleName) {
+        public void setModuleName(ModuleName moduleName) {
             this.moduleName = moduleName;
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ModuleListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleListCommand.java
@@ -22,10 +22,10 @@ public class ModuleListCommand extends Command {
         StringBuilder sb = new StringBuilder();
 
         for (Module m: moduleManager.getModules()) {
-            sb.append("Module Name: ");
-            sb.append(m.getModuleName() + "\n");
             sb.append("Module Code: ");
             sb.append(m.getModuleCode() + "\n");
+            sb.append("Module Name: ");
+            sb.append(m.getModuleName() + "\n");
             sb.append("\n");
         }
 

--- a/src/main/java/seedu/address/logic/parser/ModuleAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleAddCommandParser.java
@@ -9,6 +9,8 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.ModuleAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.ModuleName;
 
 /**
  * Parses input arguments and creates a new ModuleAddCommand object.
@@ -28,10 +30,10 @@ public class ModuleAddCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleAddCommand.MESSAGE_USAGE));
         }
 
-        String moduleName = argMultimap.getValue(PREFIX_MODULE_NAME).get();
-        String moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+        ModuleName moduleName = ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_MODULE_NAME).get());
 
-        Module module = new Module(moduleName, moduleCode);
+        Module module = new Module(moduleCode, moduleName);
         return new ModuleAddCommand(module);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ModuleEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleEditCommandParser.java
@@ -36,9 +36,10 @@ public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
         String moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
 
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
-        editModuleDescriptor.setModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+        editModuleDescriptor.setModuleCode(ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get()));
         if (argMultimap.getValue(PREFIX_MODULE_NAME).isPresent()) {
-            editModuleDescriptor.setModuleName(argMultimap.getValue(PREFIX_MODULE_NAME).get());
+            editModuleDescriptor.setModuleName(
+                    ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_MODULE_NAME).get()));
         }
 
         if (!editModuleDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.ModuleName;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -144,5 +146,35 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String moduleCode} into a {@code ModuleCode}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code moduleCode} is invalid.
+     */
+    public static ModuleCode parseModuleCode(String moduleCode) throws ParseException {
+        requireNonNull(moduleCode);
+        String trimmedModuleCode = moduleCode.trim();
+        if (!ModuleCode.isValidModuleCode(trimmedModuleCode)) {
+            throw new ParseException(ModuleCode.MESSAGE_MODULE_CODE_CONSTRAINT);
+        }
+        return new ModuleCode(trimmedModuleCode);
+    }
+
+    /**
+     * Parses a {@code String moduleName} into a {@code ModuleName}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code moduleName} is invalid.
+     */
+    public static ModuleName parseModuleName(String moduleName) throws ParseException {
+        requireNonNull(moduleName);
+        String trimmedModuleName = moduleName.trim();
+        if (!ModuleName.isValidModuleName(trimmedModuleName)) {
+            throw new ParseException(ModuleName.MESSAGE_MODULE_NAME_CONSTRAINTS);
+        }
+        return new ModuleName(trimmedModuleName);
     }
 }

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -4,13 +4,18 @@ package seedu.address.model.module;
  * Represents a module in Trajectory
  */
 public class Module {
-    private static final String MODULE_CODE_VALIDATION_REGEX = "^[A-Z]{2,3}[1-9]{1}[0-9]{3}[A-Z]{0,1}$";
     private String name;
     private String code;
+
+    private ModuleCode moduleCode;
 
     public Module(String name, String code) {
         this.name = name;
         this.code = code;
+    }
+
+    public Module(ModuleCode code) {
+        this.moduleCode = code;
     }
 
     public String getModuleName() {
@@ -21,8 +26,13 @@ public class Module {
         return this.code;
     }
 
+    public ModuleCode getCode() {
+        return this.moduleCode;
+    }
+
     /**
      * Returns true if both modules have the same module code and name.
+     * This defines a weaker notion of equality between two modules.
      */
     public boolean isSameModule(Module otherModule) {
         if (otherModule == this) {
@@ -42,5 +52,24 @@ public class Module {
                 .append(" Module Name: ")
                 .append(getModuleName());
         return builder.toString();
+    }
+
+    /**
+     * Returns true if both modules have the same module code and data fields.
+     * This defines a stronger notion of equality between two modules.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Module)) {
+            return false;
+        }
+
+        Module otherModule = (Module) other;
+        return otherModule.getModuleCode().equals((getModuleCode()))
+                && otherModule.getModuleName().equals(getModuleName());
     }
 }

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -4,30 +4,20 @@ package seedu.address.model.module;
  * Represents a module in Trajectory
  */
 public class Module {
-    private String name;
-    private String code;
-
     private ModuleCode moduleCode;
+    private ModuleName moduleName;
 
-    public Module(String name, String code) {
-        this.name = name;
-        this.code = code;
+    public Module(ModuleCode moduleCode, ModuleName moduleName) {
+        this.moduleCode = moduleCode;
+        this.moduleName = moduleName;
     }
 
-    public Module(ModuleCode code) {
-        this.moduleCode = code;
-    }
-
-    public String getModuleName() {
-        return this.name;
-    }
-
-    public String getModuleCode() {
-        return this.code;
-    }
-
-    public ModuleCode getCode() {
+    public ModuleCode getModuleCode() {
         return this.moduleCode;
+    }
+
+    public ModuleName getModuleName() {
+        return this.moduleName;
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -8,6 +8,11 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}
  */
 public class ModuleCode {
+
+    public static final String MESSAGE_MODULE_CODE_CONSTRAINT =
+            "Module code should begin with 2 or 3 uppercase letters, followed by a 4-digit number and an optional"
+            + " uppercase letter at the end.";
+
     /*
      * The first 2 or 3 (optional) characters must be uppercase letters.
      * The following 1 character must be an integer from 1-9 (0 is not valid!).
@@ -16,10 +21,6 @@ public class ModuleCode {
      * This final character must be an uppercase letter.
      */
     private static final String MODULE_CODE_VALIDATION_REGEX = "^[A-Z]{2,3}[1-9][0-9]{3}[A-Z]?$";
-
-    private static final String MESSAGE_MODULE_CODE_CONSTRAINT =
-            "Module code should begin with 2 uppercase letters, followed by a 4-digit number and an optional"
-            + " uppercase letter at the end.";
 
     public final String moduleCode;
 

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -1,0 +1,54 @@
+package seedu.address.model.module;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a module code of a Module in Trajectory
+ * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}
+ */
+public class ModuleCode {
+    /*
+     * The first 2 or 3 (optional) characters must be uppercase letters.
+     * The following 1 character must be an integer from 1-9 (0 is not valid!).
+     * The subsequent 3 characters must be integers from 0-9.
+     * Optionally, one more character may be added at the end to denote subtypes of a module.
+     * This final character must be an uppercase letter.
+     */
+    private static final String MODULE_CODE_VALIDATION_REGEX = "^[A-Z]{2,3}[1-9][0-9]{3}[A-Z]?$";
+
+    private static final String MESSAGE_MODULE_CODE_CONSTRAINT =
+            "Module code should begin with 2 uppercase letters, followed by a 4-digit number and an optional"
+            + " uppercase letter at the end.";
+
+    public final String moduleCode;
+
+    /**
+     * Constructs a {@code ModuleCode}.
+     * @param moduleCode has to be a valid module code.
+     */
+    public ModuleCode(String moduleCode) {
+        requireNonNull(moduleCode);
+        checkArgument(isValidModuleCode(moduleCode), MESSAGE_MODULE_CODE_CONSTRAINT);
+        this.moduleCode = moduleCode;
+    }
+
+    /**
+     * Returns true if the input is a valid module code
+     */
+    public static boolean isValidModuleCode(String input) {
+        return input.matches(MODULE_CODE_VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return this.moduleCode;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ModuleCode // instanceof handles nulls
+                && moduleCode.equals(((ModuleCode) other).moduleCode)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModuleManager.java
+++ b/src/main/java/seedu/address/model/module/ModuleManager.java
@@ -3,8 +3,11 @@ package seedu.address.model.module;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.StorageController;
 import seedu.address.storage.adapter.XmlAdaptedModule;
 
@@ -12,6 +15,8 @@ import seedu.address.storage.adapter.XmlAdaptedModule;
  * This module manager stores modules for Trajectory.
  */
 public class ModuleManager {
+
+    private static final Logger logger = LogsCenter.getLogger(ModuleManager.class);
 
     private ArrayList<Module> modules = new ArrayList<>();
 
@@ -47,8 +52,12 @@ public class ModuleManager {
      */
     private void readModuleList() {
         ArrayList<XmlAdaptedModule> xmlModuleList = StorageController.getModuleStorage();
-        for (XmlAdaptedModule xmlModule : xmlModuleList) {
-            modules.add(xmlModule.toModelType());
+        try {
+            for (XmlAdaptedModule xmlModule : xmlModuleList) {
+                modules.add(xmlModule.toModelType());
+            }
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found when reading module list: " + ive.getMessage());
         }
     }
 
@@ -69,7 +78,7 @@ public class ModuleManager {
      */
     public Module getModuleByModuleCode(String moduleCode) {
         return this.modules.stream()
-                .filter(module -> module.getModuleCode().equals(moduleCode))
+                .filter(module -> module.getModuleCode().moduleCode.equals(moduleCode))
                 .findAny()
                 .orElse(null);
     }

--- a/src/main/java/seedu/address/model/module/ModuleName.java
+++ b/src/main/java/seedu/address/model/module/ModuleName.java
@@ -1,0 +1,55 @@
+package seedu.address.model.module;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a module name of a Module in Trajectory
+ * Guarantees: immutable; is valid as declared in {@link #isValidModuleName(String)}
+ */
+public class ModuleName {
+
+    /*
+     * The first character of the module name must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     * The regex allows hyphens (-) for hyphenated words,
+     * and ampersands (&) for shortening lengthy names with the word "and".
+     * The 2 accepted symbols are not allowed as the first character of the module name.
+     */
+    private static final String MODULE_NAME_VALIDATION_REGEX = "^[a-zA-z0-9][a-zA-z0-9-& ]+$";
+
+    private static final String MESSAGE_MODULE_NAME_CONSTRAINTS =
+            "Module names should only contain alphanumeric characters, spaces, hyphens (-), and ampersands (&),"
+            + " and it should not be blank";
+
+    public final String moduleName;
+
+    /**
+     * Constructs a {@code ModuleName}.
+     * @param moduleName must be a valid module name.
+     */
+    public ModuleName(String moduleName) {
+        requireNonNull(moduleName);
+        checkArgument(isValidModuleName(moduleName), MESSAGE_MODULE_NAME_CONSTRAINTS);
+        this.moduleName = moduleName;
+    }
+
+    /**
+     * Returns true if the input is a valid module name.
+     */
+    public static boolean isValidModuleName(String input) {
+        return input.matches(MODULE_NAME_VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return this.moduleName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ModuleName // instanceof handles nulls
+                && moduleName.equals(((ModuleName) other).moduleName)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModuleName.java
+++ b/src/main/java/seedu/address/model/module/ModuleName.java
@@ -9,6 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class ModuleName {
 
+    public static final String MESSAGE_MODULE_NAME_CONSTRAINTS =
+            "Module name should only contain alphanumeric characters, spaces, hyphens (-), and ampersands (&),"
+            + " and it should not be blank.";
+
     /*
      * The first character of the module name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
@@ -17,10 +21,6 @@ public class ModuleName {
      * The 2 accepted symbols are not allowed as the first character of the module name.
      */
     private static final String MODULE_NAME_VALIDATION_REGEX = "^[a-zA-z0-9][a-zA-z0-9-& ]+$";
-
-    private static final String MESSAGE_MODULE_NAME_CONSTRAINTS =
-            "Module names should only contain alphanumeric characters, spaces, hyphens (-), and ampersands (&),"
-            + " and it should not be blank";
 
     public final String moduleName;
 

--- a/src/main/java/seedu/address/storage/adapter/XmlAdaptedModule.java
+++ b/src/main/java/seedu/address/storage/adapter/XmlAdaptedModule.java
@@ -3,13 +3,19 @@ package seedu.address.storage.adapter;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.ModuleName;
 
 /**
  * JAXB-friendly adapted version of the Module.
  */
 @XmlRootElement(name = "module")
 public class XmlAdaptedModule {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Module's %s field is missing!";
+
     @XmlElement(name = "moduleName", required = true, nillable = true)
     private String name;
     @XmlElement(name = "moduleCode", required = true, nillable = true)
@@ -33,22 +39,32 @@ public class XmlAdaptedModule {
      * Converts a Module into an {@code XmlAdaptedModule} for JAXB use
      */
     public XmlAdaptedModule(Module module) {
-        this.name = module.getModuleName();
-        this.code = module.getModuleCode();
+        this.name = module.getModuleName().moduleName;
+        this.code = module.getModuleCode().moduleCode;
     }
 
     /**
      * Converts this XmlAdaptedModule into the model's Module object
      */
-    public Module toModelType() {
-        return new Module(name, code);
-    }
+    public Module toModelType() throws IllegalValueException {
+        if (code == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleCode.class.getSimpleName()));
+        }
+        if (!ModuleCode.isValidModuleCode(code)) {
+            throw new IllegalValueException(ModuleCode.MESSAGE_MODULE_CODE_CONSTRAINT);
+        }
+        final ModuleCode moduleCode = new ModuleCode(code);
 
-    public String getModuleName() {
-        return this.name;
-    }
+        if (name == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleName.class.getSimpleName()));
+        }
+        if (!ModuleName.isValidModuleName(name)) {
+            throw new IllegalValueException(ModuleName.MESSAGE_MODULE_NAME_CONSTRAINTS);
+        }
+        final ModuleName moduleName = new ModuleName(name);
 
-    public String getModuleCode() {
-        return this.code;
+        return new Module(moduleCode, moduleName);
     }
 }

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -1,0 +1,78 @@
+package seedu.address.model.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import seedu.address.testutil.Assert;
+
+public class ModuleCodeTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new ModuleCode(null));
+    }
+
+    @Test
+    public void constructor_invalidModuleCode_throwsIllegalArgumentException() {
+        String invalidModuleCode = "";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ModuleCode(invalidModuleCode));
+    }
+
+    @Test
+    public void isValidModuleCode() {
+        // null
+        Assert.assertThrows(NullPointerException.class, () -> ModuleCode.isValidModuleCode(null));
+
+        // invalid module codes
+        assertFalse(ModuleCode.isValidModuleCode(""));  // empty string
+        assertFalse(ModuleCode.isValidModuleCode("  "));  // whitespace only
+        assertFalse(ModuleCode.isValidModuleCode("cs2113"));  // lowercase in front
+        assertFalse(ModuleCode.isValidModuleCode("CS2113t"));  // lowercase behind
+        assertFalse(ModuleCode.isValidModuleCode("CS2ii3"));  // letters instead of numbers
+        assertFalse(ModuleCode.isValidModuleCode("CS01134"));  // first digit is 0
+        assertFalse(ModuleCode.isValidModuleCode(" CS2113"));  // extra space in front
+        assertFalse(ModuleCode.isValidModuleCode("CS2113 "));  // extra space at the end
+        assertFalse(ModuleCode.isValidModuleCode("iloveCS2113"));  // contains extra characters in front
+        assertFalse(ModuleCode.isValidModuleCode("CS21134life"));  // contains extra characters behind
+
+        // valid module codes
+        assertTrue(ModuleCode.isValidModuleCode("CS2113"));  // module code with 2 letters and no optional char
+        assertTrue(ModuleCode.isValidModuleCode("CS2113T"));  // optional character at the end
+        assertTrue(ModuleCode.isValidModuleCode("GEQ1000"));  // 3-letter module code
+        assertTrue(ModuleCode.isValidModuleCode("GEQ1000X"));  // 3-letter code with optional character
+    }
+
+    @Test
+    public void toString_outputsModuleCodeInString() {
+        final String validModuleCode = "CS2113";
+        final ModuleCode validModuleCodeObj = new ModuleCode(validModuleCode);
+
+        assertEquals(validModuleCodeObj.toString(), validModuleCode);
+    }
+
+    @Test
+    public void equals() {
+        String codeCs2113 = "CS2113";
+        String codeGeq1000 = "GEQ1000";
+        ModuleCode cs2113 = new ModuleCode(codeCs2113);
+        ModuleCode geq1000 = new ModuleCode(codeGeq1000);
+
+        // same object -> returns true
+        assertTrue(cs2113.equals(cs2113));
+
+        // same module code -> returns true
+        ModuleCode cs2113Copy = new ModuleCode(codeCs2113);
+        assertTrue(cs2113.equals(cs2113Copy));
+
+        // different types -> returns false
+        assertFalse(cs2113.equals(1));
+
+        // null -> returns false
+        assertFalse(cs2113.equals(null));
+
+        // different module codes -> returns false
+        assertFalse(cs2113.equals(geq1000));
+    }
+}

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -45,7 +45,7 @@ public class ModuleCodeTest {
     }
 
     @Test
-    public void toString_outputsModuleCodeInString() {
+    public void toString_outputsModuleCodeAsString() {
         final String validModuleCode = "CS2113";
         final ModuleCode validModuleCodeObj = new ModuleCode(validModuleCode);
 

--- a/src/test/java/seedu/address/model/module/ModuleNameTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleNameTest.java
@@ -1,0 +1,77 @@
+package seedu.address.model.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import seedu.address.testutil.Assert;
+
+public class ModuleNameTest {
+
+    @Test
+    public void constructor_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new ModuleName(null));
+    }
+
+    @Test
+    public void constructor_invalidModuleName_throwsIllegalArgumentException() {
+        String invalidModuleName = "";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new ModuleName(invalidModuleName));
+    }
+
+    @Test
+    public void isValidModuleName() {
+        // null
+        Assert.assertThrows(NullPointerException.class, () -> ModuleName.isValidModuleName(null));
+
+        // invalid module names
+        assertFalse(ModuleName.isValidModuleName(""));  // empty string
+        assertFalse(ModuleName.isValidModuleName(" "));  // spaces only
+        assertFalse(ModuleName.isValidModuleName(" Software"));  // starting with a space
+        assertFalse(ModuleName.isValidModuleName("^"));  // invalid symbols only
+        assertFalse(ModuleName.isValidModuleName(" Software+")); // contains invalid symbols
+        assertFalse(ModuleName.isValidModuleName("&Software"));  // accepted symbol as the first char
+
+        // valid module names
+        assertTrue(ModuleName.isValidModuleName("Asking Questions"));  // letters only
+        assertTrue(ModuleName.isValidModuleName("Physics 2"));  // alphanumeric characters
+        assertTrue(ModuleName.isValidModuleName("12345"));  // numbers only
+        assertTrue(ModuleName.isValidModuleName("Software & OOP"));  // contains ampersand (&)
+        assertTrue(ModuleName.isValidModuleName("Object-oriented"));  // contains hyphen (-)
+        assertTrue(ModuleName.isValidModuleName("linear algebra"));  // all lowercase
+        assertTrue(ModuleName.isValidModuleName("Software Engineering & Object-Oriented Programming"));  // long
+    }
+
+    @Test
+    public void toString_outputsModuleNameAsString() {
+        final String validModuleName = "Quantitative Reasoning";
+        final ModuleName validModuleNameObj = new ModuleName(validModuleName);
+
+        assertEquals(validModuleNameObj.toString(), validModuleName);
+    }
+
+    @Test
+    public void equals() {
+        String askingQuestions = "Asking Questions";
+        String linearAlgebra = "Linear Algebra";
+        ModuleName askingQuestionsName = new ModuleName(askingQuestions);
+        ModuleName linearAlgebraName = new ModuleName(linearAlgebra);
+
+        // same object -> returns true
+        assertTrue(askingQuestionsName.equals(askingQuestionsName));
+
+        // same module code -> returns true
+        ModuleName askingQuestionsNameCopy = new ModuleName(askingQuestions);
+        assertTrue(askingQuestionsName.equals(askingQuestionsNameCopy));
+
+        // different types -> returns false
+        assertFalse(askingQuestionsName.equals(1));
+
+        // null -> returns false
+        assertFalse(askingQuestionsName.equals(null));
+
+        // different module codes -> returns false
+        assertFalse(askingQuestionsName.equals(linearAlgebraName));
+    }
+}


### PR DESCRIPTION
On matters regarding module code and name:
- Validation was implemented by abstracting module name and module code into their respective classes.
- Each of the two classes implements their own validation checks.
- Wrote comprehensive test cases for `ModuleCode` and `ModuleName`.
- Updated `Module` to use the new `ModuleCode` and `ModuleName` classes to leverage on their validation checks.

This PR also includes:
- Minor change to displaying the list of modules -- module code is now displayed before module name.
- Fixes a bug that swaps the module name and code when editing the module.

Resolves #93 and fixes #133 