### PR TITLE
Improved the command parser regex to allow multi-letter prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -53,7 +53,7 @@ public class AddressBookParser {
      * Used to separate multiple command words and args
      */
     private static final Pattern ADVANCED_COMMAND_FORMAT =
-            Pattern.compile("(?<commandWords>.*?\\S+((?<=find)|(?=(?:\\s+[0-9]|\\s+[a-z]\\/))|$))(?<arguments>.*)");
+            Pattern.compile("(?<commandWords>.*?\\S+((?<=find)|(?=(?:\\s+[0-9]|\\s+[a-z]+\\/))|$))(?<arguments>.*)");
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -19,7 +19,11 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_NOTE_DATE = new Prefix("d/");
 
-    /* TODO: Reorder the prefixes above in alphabetical order using the following template */
+
+
+
+    /* TODO: Reorder the prefixes above in alphabetical order using the foll
+    owing template */
     /* Class prefixes */
     public static final Prefix PREFIX_CLASSNAME = new Prefix("c/");
     public static final Prefix PREFIX_MAXENROLLMENT = new Prefix("e/");
@@ -30,7 +34,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_COURSE_FACULTY = new Prefix("f/");
     /* Gradebook prefixes */
     /* Module prefixes */
-    public static final Prefix PREFIX_MODULE_CODE = new Prefix("c/");
-    public static final Prefix PREFIX_MODULE_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_MODULE_CODE = new Prefix("mc/");
+    public static final Prefix PREFIX_MODULE_NAME = new Prefix("mn/");
     /* Note prefixes */
 }


### PR DESCRIPTION
Also updated module-related prefixes to `mc/` for module code, and `mn/` for module name

Resolves #135 