### PR TITLE
Enhanced notes to have more detailed attributes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NoteAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteAddCommand.java
@@ -2,7 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -18,12 +23,19 @@ public class NoteAddCommand extends Command {
 
     public static final String COMMAND_WORD = "note add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a note. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a note to Trajectory. "
             + "Parameters: "
-            + PREFIX_MODULE_CODE + "MODULE_CODE "
-            + "[" + PREFIX_NOTE_DATE + "DATE]\n"
+            + "[" + PREFIX_MODULE_CODE + "MODULE_CODE] "
+            + "[" + PREFIX_NOTE_TITLE + "TITLE] "
+            + "[" + PREFIX_NOTE_START_DATE + "START_DATE] "
+            + "[" + PREFIX_NOTE_START_TIME + "START_TIME] "
+            + "[" + PREFIX_NOTE_END_DATE + "END_DATE] "
+            + "[" + PREFIX_NOTE_END_TIME + "END_TIME] "
+            + "[" + PREFIX_NOTE_LOCATION + "LOCATION]\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_MODULE_CODE + "CS2113";
+            + PREFIX_NOTE_TITLE + "My First Note "
+            + PREFIX_NOTE_START_DATE + "30-10-2020 "
+            + PREFIX_NOTE_LOCATION + "Columbia, Schermerhorn 614";
 
     public static final String MESSAGE_SUCCESS = "Note has been added to %1$s.";
     public static final String MESSAGE_CANCEL = "Note creation has been cancelled.";

--- a/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
@@ -30,15 +30,35 @@ public class NoteEditCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Note has been edited.";
     public static final String MESSAGE_CANCEL = "Edit note operation has been cancelled.";
     public static final String MESSAGE_INVALID_INDEX = "Invalid input!\nINDEX %1$s is out of bounds.";
+    public static final String MESSAGE_INVALID_DATE_TIME_DIFFERENCE =
+            "Invalid input! Please make sure the start date/time is earlier than the end date/time.";
 
     private final int index;
     private final String moduleCode;
-    private final String date;
+    private final String title;
+    private final String startDate;
+    private final String startTime;
+    private final String endDate;
+    private final String endTime;
+    private final String location;
 
-    public NoteEditCommand(int index, String moduleCode, String date) {
+    public NoteEditCommand(
+            int index,
+            String moduleCode,
+            String title,
+            String startDate,
+            String startTime,
+            String endDate,
+            String endTime,
+            String location) {
         this.index = index;
         this.moduleCode = moduleCode;
-        this.date = date;
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endDate = endDate;
+        this.endTime = endTime;
+        this.location = location;
     }
 
     @Override
@@ -52,18 +72,40 @@ public class NoteEditCommand extends Command {
 
         Note noteToEdit = noteManager.getNoteAt(index - 1);
 
-        if (!moduleCode.isEmpty()) {
-            noteToEdit.setModuleCode(moduleCode);
-        }
-
-        if (!date.isEmpty()) {
-            noteToEdit.setDate(date);
-        }
+        // TODO: Validate date & time difference for 'start' and 'end' here
 
         NoteTextEditWindow noteTextEditWindow = new NoteTextEditWindow(noteToEdit);
         noteTextEditWindow.showAndWait();
 
         if (!noteTextEditWindow.isCancelled()) {
+            if (!moduleCode.isEmpty()) {
+                noteToEdit.setModuleCode(moduleCode);
+            }
+
+            if (!title.isEmpty()) {
+                noteToEdit.setTitle(title);
+            }
+
+            if (!startDate.isEmpty()) {
+                noteToEdit.setStartDate(startDate);
+            }
+
+            if (!startTime.isEmpty()) {
+                noteToEdit.setStartTime(startTime);
+            }
+
+            if (!endDate.isEmpty()) {
+                noteToEdit.setEndDate(endDate);
+            }
+
+            if (!endTime.isEmpty()) {
+                noteToEdit.setEndTime(endTime);
+            }
+
+            if (!location.isEmpty()) {
+                noteToEdit.setLocation(location);
+            }
+
             noteManager.saveNoteList();
 
             return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/NoteListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteListCommand.java
@@ -50,12 +50,59 @@ public class NoteListCommand extends Command {
 
         for (Note n: noteManager.getFilteredNotes()) {
             sb.append(listId + ":\n");
+
             sb.append("Module Code: ");
-            sb.append(n.getModuleCode() + "\n");
-            sb.append("Date: ");
-            sb.append(n.getDate() + "\n");
+            if (!n.getModuleCode().isEmpty()) {
+                sb.append(n.getModuleCode() + "\n");
+            } else {
+                sb.append("Not assigned\n");
+            }
+
+            sb.append("Title: ");
+            if (!n.getTitle().isEmpty()) {
+                sb.append(n.getTitle() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
+            sb.append("Start Date: ");
+            if (!n.getStartDate().isEmpty()) {
+                sb.append(n.getStartDate() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
+            sb.append("Start Time: ");
+            if (!n.getStartTime().isEmpty()) {
+                sb.append(n.getStartTime() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
+            sb.append("End Date: ");
+            if (!n.getEndDate().isEmpty()) {
+                sb.append(n.getEndDate() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
+            sb.append("End Time: ");
+            if (!n.getEndTime().isEmpty()) {
+                sb.append(n.getEndTime() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
+            sb.append("Location: ");
+            if (!n.getLocation().isEmpty()) {
+                sb.append(n.getLocation() + "\n");
+            } else {
+                sb.append("Not specified\n");
+            }
+
             sb.append("Note:\n");
             sb.append(n.getNoteText() + ((listId < size) ? "\n\n" : "\n"));
+
             listId++;
         }
 

--- a/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
@@ -3,6 +3,12 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 
 import java.util.stream.Stream;
 
@@ -23,22 +29,74 @@ public class NoteAddCommandParser implements Parser<NoteAddCommand> {
      */
     public NoteAddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_MODULE_CODE, PREFIX_NOTE_DATE);
+                ArgumentTokenizer.tokenize(args,
+                        PREFIX_MODULE_CODE,
+                        PREFIX_NOTE_DATE,
+                        PREFIX_NOTE_TITLE,
+                        PREFIX_NOTE_START_DATE,
+                        PREFIX_NOTE_START_TIME,
+                        PREFIX_NOTE_END_DATE,
+                        PREFIX_NOTE_END_TIME,
+                        PREFIX_NOTE_LOCATION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_MODULE_CODE)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteAddCommand.MESSAGE_USAGE));
+        String moduleCode = "";
+        String title = "";
+        String startDate = "";
+        String startTime = "";
+        String endDate = "";
+        String endTime = "";
+        String location = "";
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    NoteAddCommand.MESSAGE_USAGE));
         }
 
-        String moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
-        String noteDate = (argMultimap.getValue(PREFIX_NOTE_DATE).isPresent())
-                ? argMultimap.getValue(PREFIX_NOTE_DATE).get() : "No Date";
-
-        if (noteDate.trim().length() == 0) {
-            noteDate = "No Date";
+        if (argMultimap.getValue(PREFIX_MODULE_CODE).isPresent()) {
+            // TODO: Check validity of input moduleCode value
+            moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
         }
 
-        Note note = new Note(moduleCode, noteDate);
+        if (argMultimap.getValue(PREFIX_NOTE_TITLE).isPresent()) {
+            title = argMultimap.getValue(PREFIX_NOTE_TITLE).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_START_DATE).isPresent()) {
+            // TODO: Check validity of input startDate value
+            startDate = argMultimap.getValue(PREFIX_NOTE_START_DATE).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_START_TIME).isPresent()) {
+            // TODO: Check validity of input startTime value
+            startTime = argMultimap.getValue(PREFIX_NOTE_START_TIME).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_END_DATE).isPresent()) {
+            // TODO: Check validity of input endDate value
+            endDate = argMultimap.getValue(PREFIX_NOTE_END_DATE).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_END_TIME).isPresent()) {
+            // TODO: Check validity of input endTime value
+            endTime = argMultimap.getValue(PREFIX_NOTE_END_TIME).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_LOCATION).isPresent()) {
+            location = argMultimap.getValue(PREFIX_NOTE_LOCATION).get();
+        }
+
+        // TODO: Validate date & time difference for 'start' and 'end' here
+
+        Note note = new Note(
+                moduleCode,
+                title,
+                startDate,
+                startTime,
+                endDate,
+                endTime,
+                location,
+                "");
+
         return new NoteAddCommand(note);
     }
 

--- a/src/main/java/seedu/address/logic/parser/NoteEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteEditCommandParser.java
@@ -2,7 +2,12 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,7 +42,14 @@ public class NoteEditCommandParser implements Parser<NoteEditCommand> {
         final String optionalParams = matcher.group("optionalParams");
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(optionalParams, PREFIX_MODULE_CODE, PREFIX_NOTE_DATE);
+                ArgumentTokenizer.tokenize(optionalParams,
+                        PREFIX_MODULE_CODE,
+                        PREFIX_NOTE_TITLE,
+                        PREFIX_NOTE_START_DATE,
+                        PREFIX_NOTE_START_TIME,
+                        PREFIX_NOTE_END_DATE,
+                        PREFIX_NOTE_END_TIME,
+                        PREFIX_NOTE_LOCATION);
 
         if (!index.matches("\\d+") || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -45,15 +57,54 @@ public class NoteEditCommandParser implements Parser<NoteEditCommand> {
         }
 
         String moduleCode = "";
-        String date = "";
+        String title = "";
+        String startDate = "";
+        String startTime = "";
+        String endDate = "";
+        String endTime = "";
+        String location = "";
+
         if (argMultimap.getValue(PREFIX_MODULE_CODE).isPresent()) {
+            // TODO: Check validity of input moduleCode value
             moduleCode = argMultimap.getValue(PREFIX_MODULE_CODE).get();
         }
 
-        if (argMultimap.getValue(PREFIX_NOTE_DATE).isPresent()) {
-            date = argMultimap.getValue(PREFIX_NOTE_DATE).get();
+        if (argMultimap.getValue(PREFIX_NOTE_TITLE).isPresent()) {
+            title = argMultimap.getValue(PREFIX_NOTE_TITLE).get();
         }
 
-        return new NoteEditCommand(Integer.parseInt(index), moduleCode, date);
+        if (argMultimap.getValue(PREFIX_NOTE_START_DATE).isPresent()) {
+            // TODO: Check validity of input startDate value
+            startDate = argMultimap.getValue(PREFIX_NOTE_START_DATE).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_START_TIME).isPresent()) {
+            // TODO: Check validity of input startTime value
+            startTime = argMultimap.getValue(PREFIX_NOTE_START_TIME).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_END_DATE).isPresent()) {
+            // TODO: Check validity of input endDate value
+            endDate = argMultimap.getValue(PREFIX_NOTE_END_DATE).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_END_TIME).isPresent()) {
+            // TODO: Check validity of input endTime value
+            endTime = argMultimap.getValue(PREFIX_NOTE_END_TIME).get();
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE_LOCATION).isPresent()) {
+            location = argMultimap.getValue(PREFIX_NOTE_LOCATION).get();
+        }
+
+        return new NoteEditCommand(
+                Integer.parseInt(index),
+                moduleCode,
+                title,
+                startDate,
+                startTime,
+                endDate,
+                endTime,
+                location);
     }
 }

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -6,19 +6,31 @@ package seedu.address.model.note;
 public class Note {
 
     private String moduleCode;
-    private String date;
+    private String title;
+    private String startDate;
+    private String startTime;
+    private String endDate;
+    private String endTime;
+    private String location;
     private String noteText;
 
-    public Note(String moduleCode, String date) {
-        this.moduleCode = moduleCode;
-        this.date = date;
-        this.noteText = "";
-    }
 
-    public Note(String moduleCode, String date, String text) {
+    public Note(String moduleCode,
+                String title,
+                String startDate,
+                String startTime,
+                String endDate,
+                String endTime,
+                String location,
+                String noteText) {
         this.moduleCode = moduleCode;
-        this.date = date;
-        this.noteText = text;
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endDate = endDate;
+        this.endTime = endTime;
+        this.location = location;
+        this.noteText = noteText;
     }
 
     public String getModuleCode() {
@@ -29,12 +41,52 @@ public class Note {
         this.moduleCode = moduleCode;
     }
 
-    public String getDate() {
-        return this.date;
+    public String getTitle() {
+        return this.title;
     }
 
-    public void setDate(String date) {
-        this.date = date;
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getStartDate() {
+        return this.startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getStartTime() {
+        return this.startTime;
+    }
+
+    public void setStartTime(String startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getEndDate() {
+        return this.endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getEndTime() {
+        return this.endTime;
+    }
+
+    public void setEndTime(String endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getLocation() {
+        return this.location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
     }
 
     public String getNoteText() {

--- a/src/main/java/seedu/address/storage/adapter/XmlAdaptedNote.java
+++ b/src/main/java/seedu/address/storage/adapter/XmlAdaptedNote.java
@@ -17,11 +17,26 @@ public class XmlAdaptedNote {
     @XmlElement(name = "moduleCode", required = true, nillable = true)
     private String moduleCode;
 
-    @XmlElement(name = "date", required = true, nillable = true)
-    private String date;
+    @XmlElement(name = "title", required = true, nillable = true)
+    private String title;
 
-    @XmlElement(name = "text", required = true, nillable = true)
-    private String text;
+    @XmlElement(name = "startDate", required = true, nillable = true)
+    private String startDate;
+
+    @XmlElement(name = "startTime", required = true, nillable = true)
+    private String startTime;
+
+    @XmlElement(name = "endDate", required = true, nillable = true)
+    private String endDate;
+
+    @XmlElement(name = "endTime", required = true, nillable = true)
+    private String endTime;
+
+    @XmlElement(name = "location", required = true, nillable = true)
+    private String location;
+
+    @XmlElement(name = "noteText", required = true, nillable = true)
+    private String noteText;
 
     /**
      * Constructs an XmlAdaptedNote.
@@ -32,10 +47,23 @@ public class XmlAdaptedNote {
     /**
      * Constructs an {@code XmlAdaptedNote} with the given note details
      */
-    public XmlAdaptedNote(String moduleCode, String date, String text) {
+    public XmlAdaptedNote(
+            String moduleCode,
+            String title,
+            String startDate,
+            String startTime,
+            String endDate,
+            String endTime,
+            String location,
+            String noteText) {
         this.moduleCode = moduleCode;
-        this.date = date;
-        this.text = text;
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endDate = endDate;
+        this.endTime = endTime;
+        this.location = location;
+        this.noteText = noteText;
     }
 
     /**
@@ -43,26 +71,59 @@ public class XmlAdaptedNote {
      */
     public XmlAdaptedNote(Note note) {
         this.moduleCode = note.getModuleCode();
-        this.date = note.getDate();
-        this.text = note.getNoteText();
+        this.title = note.getTitle();
+        this.startDate = note.getStartDate();
+        this.startTime = note.getStartTime();
+        this.endDate = note.getEndDate();
+        this.endTime = note.getEndTime();
+        this.location = note.getLocation();
+        this.noteText = note.getNoteText();
     }
 
     /**
      * Converts this XmlAdaptedNote into the model's Note object
      */
     public Note toModelType() {
-        return new Note(moduleCode, date, text);
+        return new Note(
+                moduleCode,
+                title,
+                startDate,
+                startTime,
+                endDate,
+                endTime,
+                location,
+                noteText);
     }
 
     public String getModuleCode() {
         return this.moduleCode;
     }
 
-    public String getDate() {
-        return this.date;
+    public String getTitle() {
+        return this.title;
     }
 
-    public String getText() {
-        return this.text;
+    public String getStartDate() {
+        return this.startDate;
+    }
+
+    public String getStartTime() {
+        return this.startTime;
+    }
+
+    public String getEndDate() {
+        return this.endDate;
+    }
+
+    public String getEndTime() {
+        return this.endTime;
+    }
+
+    public String getLocation() {
+        return this.location;
+    }
+
+    public String getNoteText() {
+        return this.noteText;
     }
 }

--- a/src/main/java/seedu/address/ui/NoteEntryPrompt.java
+++ b/src/main/java/seedu/address/ui/NoteEntryPrompt.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
@@ -17,15 +18,20 @@ import seedu.address.model.note.Note;
 public class NoteEntryPrompt {
 
     private static final String FXML = "NoteEntryPrompt.fxml";
+    private static final String NOTE_TEXT_EMPTY_MESSAGE = "Saving failed! The field is empty.";
     private final KeyCombination keyCombinationSave = new KeyCodeCombination(KeyCode.S, KeyCombination.CONTROL_DOWN);
     private final KeyCombination keyCombinationCancel = new KeyCodeCombination(KeyCode.Q, KeyCombination.CONTROL_DOWN);
 
     @FXML
     private TextArea noteContent;
 
+    @FXML
+    private Label feedbackLabel;
+
     private Stage dialogStage;
     private Note note;
 
+    private boolean feedbackLabelIsDisplayed = false;
     private boolean isCancelled = false;
 
     public NoteEntryPrompt() {
@@ -54,9 +60,19 @@ public class NoteEntryPrompt {
 
     /**
      * Handles the key press event, {@code keyEvent}.
+     *
+     * Key combination CTRL+S will save the note if the TextArea is not blank,
+     * otherwise, displays an error message.
+     *
+     * Key combination CTRL+Q will close the window without saving the note.
      */
     @FXML
     private void handleKeyPress(KeyEvent keyEvent) {
+        if (feedbackLabelIsDisplayed && !keyEvent.getCode().isModifierKey()) {
+            feedbackLabel.setText("");
+            feedbackLabelIsDisplayed = false;
+        }
+
         if (keyCombinationSave.match(keyEvent)) {
             saveAndCloseWindow();
         }
@@ -72,10 +88,18 @@ public class NoteEntryPrompt {
     public void saveAndCloseWindow() {
         String tempNote = noteContent.getText();
 
-        if (tempNote.trim().length() > 0) {
+        if (!tempNote.trim().isEmpty()) {
             note.setNoteText(tempNote);
             dialogStage.close();
+        } else {
+            displayFeedbackLabel();
+            feedbackLabelIsDisplayed = true;
         }
+    }
+
+    private void displayFeedbackLabel() {
+        feedbackLabel.setStyle("-fx-font-size: 12; -fx-text-fill: red;");
+        feedbackLabel.setText(NOTE_TEXT_EMPTY_MESSAGE);
     }
 
     /**

--- a/src/main/resources/view/NoteEntryPromptWindow.fxml
+++ b/src/main/resources/view/NoteEntryPromptWindow.fxml
@@ -5,18 +5,28 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.text.Font?>
 
 <BorderPane styleClass="background" stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1">
    <top>
-      <Label alignment="BOTTOM_LEFT" maxHeight="45.0" prefHeight="45.0" prefWidth="350.0" styleClass="label-bright" stylesheets="@DarkTheme.css" text="Enter note:">
-         <font>
-            <Font size="13.0" />
-         </font>
-         <padding>
-            <Insets left="10.0" />
-         </padding>
-      </Label>
+      <HBox>
+         <children>
+            <Label alignment="BOTTOM_LEFT" maxHeight="158.0" prefHeight="13.0" prefWidth="102.0" styleClass="label-bright" stylesheets="@DarkTheme.css" text="Enter note:" HBox.hgrow="NEVER">
+               <font>
+                  <Font size="13.0" />
+               </font>
+               <padding>
+                  <Insets left="10.0" />
+               </padding>
+            </Label>
+            <Label fx:id="feedbackLabel" alignment="BOTTOM_RIGHT" prefHeight="28.0" prefWidth="250.0" textFill="RED">
+               <padding>
+                  <Insets right="10.0" />
+               </padding>
+            </Label>
+         </children>
+      </HBox>
    </top>
    <center>
       <AnchorPane BorderPane.alignment="CENTER">

--- a/src/test/java/seedu/address/logic/commands/NoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteEditCommandTest.java
@@ -19,9 +19,35 @@ public class NoteEditCommandTest {
 
     private static NoteManager noteManager = NoteManager.getInstance();
 
-    private NoteBuilder note1 = new NoteBuilder("CS1010", "10/10/2018", "C");
-    private NoteBuilder note2 = new NoteBuilder("CS2040C", "20/4/2018", "C++");
-    private NoteBuilder note3 = new NoteBuilder("CS2113", "31/12/2018", "Java");
+    private NoteBuilder note1 = new NoteBuilder(
+            "CS1010",
+            "First note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C");
+
+    private NoteBuilder note2 = new NoteBuilder(
+            "CS2040C",
+            "Second note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C++");
+
+    private NoteBuilder note3 = new NoteBuilder(
+            "CS2113",
+            "Third note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Java");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -41,8 +67,24 @@ public class NoteEditCommandTest {
 
         int index = 5; // arraylist size: 3, accessed index = 4 (zero-based) -> out of bounds
         String newModuleCode = "CS5000";
-        String newDate = "1/1/2019";
-        NoteEditCommand noteEditCommand = new NoteEditCommand(index, newModuleCode, newDate);
+        String newTitle = "My new title";
+        String newStartDate = "1/1/2019";
+        String newStartTime = "11:00 AM";
+        String newEndDate = "1/1/2019";
+        String newEndTime = "1:00 PM";
+        String newLocation = "National University of Singapore";
+
+        NoteEditCommand noteEditCommand =
+                new NoteEditCommand(
+                        index,
+                        newModuleCode,
+                        newTitle,
+                        newStartDate,
+                        newStartTime,
+                        newEndDate,
+                        newEndTime,
+                        newLocation
+                );
 
         thrown.expect(CommandException.class);
         thrown.expectMessage(String.format(NoteEditCommand.MESSAGE_INVALID_INDEX, index));

--- a/src/test/java/seedu/address/logic/commands/NoteListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteListCommandTest.java
@@ -21,9 +21,35 @@ public class NoteListCommandTest {
 
     private static NoteManager noteManager = NoteManager.getInstance();
 
-    private NoteBuilder note1 = new NoteBuilder("CS1010", "10/10/2018", "C");
-    private NoteBuilder note2 = new NoteBuilder("CS2040C", "20/4/2018", "C++");
-    private NoteBuilder note3 = new NoteBuilder("CS2113", "31/12/2018", "Java");
+    private NoteBuilder note1 = new NoteBuilder(
+            "CS1010",
+            "First note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C");
+
+    private NoteBuilder note2 = new NoteBuilder(
+            "CS2040C",
+            "Second note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C++");
+
+    private NoteBuilder note3 = new NoteBuilder(
+            "CS2113",
+            "Third note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Java");
 
     @Before
     public void setUp() {

--- a/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
@@ -50,18 +50,4 @@ public class NoteAddCommandParserTest {
 
         assertNotNull(noteAddCommand);
     }
-
-    @Test
-    public void parse_missingMandatoryFields_throwsParseException() throws ParseException {
-        String expectedMessage = String.format(
-                Messages.MESSAGE_INVALID_COMMAND_FORMAT, NoteAddCommand.MESSAGE_USAGE);
-
-        // missing mandatory field argument
-        String args = " " + PREFIX_NOTE_DATE + "1/2/2020";
-
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessage);
-
-        parser.parse(args);
-    }
 }

--- a/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
@@ -28,6 +28,36 @@ public class NoteListCommandParserTest {
 
     private NoteListCommandParser parser = new NoteListCommandParser();
 
+    private NoteBuilder note1 = new NoteBuilder(
+            "CS1010",
+            "First note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C");
+
+    private NoteBuilder note2 = new NoteBuilder(
+            "CS2040C",
+            "Second note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C++");
+
+    private NoteBuilder note3 = new NoteBuilder(
+            "CS2113",
+            "Third note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Java");
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -55,10 +85,9 @@ public class NoteListCommandParserTest {
     public void parse_validArgs_success() throws ParseException, CommandException {
         String unwantedMessage = NoteListCommand.MESSAGE_NOT_FOUND;
 
-        NoteBuilder note1 = new NoteBuilder("CS2113", "30/03/2030", "Java");
-        NoteBuilder note2 = new NoteBuilder("CS2040C", "03/03/2040", "C++");
         noteManager.addNote(note1.build());
         noteManager.addNote(note2.build());
+        noteManager.addNote(note3.build());
         noteManager.saveNoteList();
 
         // valid empty args

--- a/src/test/java/seedu/address/model/note/NoteManagerTest.java
+++ b/src/test/java/seedu/address/model/note/NoteManagerTest.java
@@ -17,9 +17,35 @@ public class NoteManagerTest {
 
     private static NoteManager noteManager = NoteManager.getInstance();
 
-    private NoteBuilder note1 = new NoteBuilder("CS1010", "10/10/2018", "C");
-    private NoteBuilder note2 = new NoteBuilder("CS2040C", "20/4/2018", "C++");
-    private NoteBuilder note3 = new NoteBuilder("CS2113", "31/12/2018", "Java");
+    private NoteBuilder note1 = new NoteBuilder(
+            "CS1010",
+            "First note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C");
+
+    private NoteBuilder note2 = new NoteBuilder(
+            "CS2040C",
+            "Second note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "C++");
+
+    private NoteBuilder note3 = new NoteBuilder(
+            "CS2113",
+            "Third note",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Java");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/seedu/address/testutil/NoteBuilder.java
+++ b/src/test/java/seedu/address/testutil/NoteBuilder.java
@@ -4,56 +4,131 @@ import seedu.address.model.note.Note;
 
 public class NoteBuilder {
     public static final String DEFAULT_MODULE_CODE = "CS2113";
-    public static final String DEFAULT_DATE = "21/12/2113";
-    public static final String DEFAULT_TEXT = "CS2113 Rocks!";
+    public static final String DEFAULT_TITLE = "My note";
+    public static final String DEFAULT_START_DATE = "21/12/2113";
+    public static final String DEFAULT_START_TIME = "10:00 AM";
+    public static final String DEFAULT_END_DATE = "22/12/2113";
+    public static final String DEFAULT_END_TIME = "10:00 AM";
+    public static final String DEFAULT_LOCATION = "National University of Singapore";
+    public static final String DEFAULT_NOTE_TEXT = "CS2113 Rocks!";
 
     private String moduleCode;
-    private String date;
+    private String title;
+    private String startDate;
+    private String startTime;
+    private String endDate;
+    private String endTime;
+    private String location;
     private String noteText;
 
-
+    /**
+     * Empty constructor for NoteBuilder that initializes the
+     * note with default values.
+     */
     public NoteBuilder() {
-        moduleCode = DEFAULT_MODULE_CODE;
-        date = DEFAULT_DATE;
-        noteText = DEFAULT_TEXT;
+        this.moduleCode = DEFAULT_MODULE_CODE;
+        this.title = DEFAULT_TITLE;
+        this.startDate = DEFAULT_START_DATE;
+        this.startTime = DEFAULT_START_TIME;
+        this.endDate = DEFAULT_END_DATE;
+        this.endTime = DEFAULT_END_TIME;
+        this.location = DEFAULT_LOCATION;
+        this.noteText = DEFAULT_NOTE_TEXT;
     }
 
     /**
-     * Initializes the NoteBuilder with the data of {@code noteToCopy}.
+     * Initializes the note with given parameters.
      */
-    public NoteBuilder(Note noteToCopy) {
-        moduleCode = noteToCopy.getModuleCode();
-        date = noteToCopy.getDate();
-        noteText = noteToCopy.getNoteText();
-    }
-
-    /**
-     * Initializes the NoteBuilder with given parameters.
-     */
-    public NoteBuilder(String moduleCode, String date, String noteText) {
+    public NoteBuilder(String moduleCode,
+                       String title,
+                       String startDate,
+                       String startTime,
+                       String endDate,
+                       String endTime,
+                       String location,
+                       String noteText) {
         this.moduleCode = moduleCode;
-        this.date = date;
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endDate = endDate;
+        this.endTime = endTime;
+        this.location = location;
         this.noteText = noteText;
     }
 
+    /**
+     * Initializes the note with the data from {@code noteToCopy}.
+     */
+    public NoteBuilder(Note noteToCopy) {
+        this.moduleCode = noteToCopy.getModuleCode();
+        this.title = noteToCopy.getTitle();
+        this.startDate = noteToCopy.getStartDate();
+        this.startTime = noteToCopy.getStartTime();
+        this.endDate = noteToCopy.getEndDate();
+        this.endTime = noteToCopy.getEndTime();
+        this.location = noteToCopy.getLocation();
+        this.noteText = noteToCopy.getNoteText();
+    }
+
     public String getModuleCode() {
-        return moduleCode;
+        return this.moduleCode;
     }
 
     public void setModuleCode(String moduleCode) {
         this.moduleCode = moduleCode;
     }
 
-    public String getDate() {
-        return date;
+    public String getTitle() {
+        return this.title;
     }
 
-    public void setDate(String date) {
-        this.date = date;
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getStartDate() {
+        return this.startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getStartTime() {
+        return this.startTime;
+    }
+
+    public void setStartTime(String startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getEndDate() {
+        return this.endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getEndTime() {
+        return this.endTime;
+    }
+
+    public void setEndTime(String endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getLocation() {
+        return this.location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
     }
 
     public String getNoteText() {
-        return noteText;
+        return this.noteText;
     }
 
     public void setNoteText(String noteText) {
@@ -61,10 +136,15 @@ public class NoteBuilder {
     }
 
     public Note build() {
-        return new Note(moduleCode, date, noteText);
-    }
-
-    public Note buildWithoutNoteText() {
-        return new Note(moduleCode, date);
+        return new Note(
+                moduleCode,
+                title,
+                startDate,
+                startTime,
+                endDate,
+                endTime,
+                location,
+                noteText
+        );
     }
 }


### PR DESCRIPTION
Notes will have the following fields:
- Module Code:  The module code assigned to the note. Can be empty.
- Note title:  The title for the note. Can be used for Google calendar field `Subject`. Can be empty.
- Note start date:  For event-related notes. Marks the start of the event. Can be used for Google calendar field `Start Date`. Can be empty.
- Note start time:  The start time in the starting date. Can be used for Google calendar field `Start Time`. Can be empty. Requires start date (WIP). Can be empty.
- Note end date:  For event-related notes. Marks the end of the event. Can be used for Google calendar field `End Date`. Requires start date (WIP). Can be empty.
- Note end time:  The end time in the ending date. Can be used for Google calendar field `End Time`. Requires end date and start date/time (WIP). Can be empty.
- Location:  The location/venue of an event in the note. Can be used for Google calendar field `Location`. Can be empty.
- Note text:  The contents of the note. Required field. Cannot be empty. Can be used for Google calendar field `Description`.

Tests:
- Updated relevant test codes.

UI:
- Note add/edit window can now display an error message when trying to save with a blank text area field.

Bug fix:
- Fixes a bug in note edit command whereby cancelling the edit process still modifies some attributes of the note.

Resolves #177 
Resolves #178 