### PR TITLE
Fixed a bug in note edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
@@ -143,10 +143,6 @@ public class NoteEditCommand extends Command {
             throw new CommandException(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
         }
 
-//        if (newStartDate == null && (newStartTime != null || newEndDate != null || newEndTime != null)) {
-//            throw new CommandException(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
-//        }
-
         if (newStartDate != null && newEndDate == null) {
             newEndDate = new NoteDate(newStartDate.getDate().format(NoteDate.DATE_FORMAT));
         }

--- a/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteEditCommand.java
@@ -139,9 +139,13 @@ public class NoteEditCommand extends Command {
             newEndTime = noteToEdit.getEndTime();
         }
 
-        if (newStartDate == null && (newStartTime != null || newEndDate != null || newEndTime != null)) {
+        if (newStartDate == null && (startTime != null || newEndDate != null || endTime != null)) {
             throw new CommandException(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
         }
+
+//        if (newStartDate == null && (newStartTime != null || newEndDate != null || newEndTime != null)) {
+//            throw new CommandException(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
+//        }
 
         if (newStartDate != null && newEndDate == null) {
             newEndDate = new NoteDate(newStartDate.getDate().format(NoteDate.DATE_FORMAT));


### PR DESCRIPTION
Users can now edit notes without specifying the `START_DATE` if the note being edited initially do not have a date.

Resolves #256 