### PR TITLE
Corrected error message when entering invalid parameters for note add command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,8 +8,8 @@ public class Messages {
     public static final String MESSAGE_BLANK_FIELD = "Please do not leave any field blank.";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_DATE_FORMAT = "Invalid date format!\n"
-            + "Please follow any of these valid date formats:\n"
+    public static final String MESSAGE_INVALID_DATE_FORMAT = "Invalid date!\n"
+            + "Please enter a valid date in any of the following formats:\n"
             + "1) dd-MM-yyyy\n"
             + "2) dd/MM-yyyy\n"
             + "3) dd.MM.yyyy\n"
@@ -18,7 +18,7 @@ public class Messages {
             + "6) dd-MMM-yy\n"
             + "7) dd MMM yy";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_TIME_FORMAT = "Invalid time format!\n"
+    public static final String MESSAGE_INVALID_TIME_FORMAT = "Invalid time!\n"
             + "Please enter a time in the 12-hour format (hh:mm AM/PM). Example: 12:45 PM";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_WELCOME = "Welcome to Trajectory.";

--- a/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
@@ -132,7 +132,7 @@ public class NoteAddCommandParser implements Parser<NoteAddCommand> {
                 timeErrorFound = true;
             }
 
-            if (startDate == null) {
+            if (startDate == null && !dateErrorFound) {
                 messageErrors.append(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
                 messageErrors.append("\n\n");
                 startDateMissingErrorFound = true;
@@ -153,7 +153,7 @@ public class NoteAddCommandParser implements Parser<NoteAddCommand> {
                 }
             }
 
-            if (startDate == null) {
+            if (startDate == null && !dateErrorFound) {
                 if (!startDateMissingErrorFound) {
                     messageErrors.append(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
                     messageErrors.append("\n\n");
@@ -176,7 +176,7 @@ public class NoteAddCommandParser implements Parser<NoteAddCommand> {
                 }
             }
 
-            if (startDate == null) {
+            if (startDate == null && !dateErrorFound) {
                 if (!startDateMissingErrorFound) {
                     messageErrors.append(NoteDate.MESSAGE_START_DATE_MISSING_FIELD);
                     messageErrors.append("\n\n");


### PR DESCRIPTION
Addresses the bug issued in #283 

Entering the same command to reproduce the bug now displays the correct error message.

![ss1](https://user-images.githubusercontent.com/35735624/47947621-098c2e80-df5b-11e8-8fe3-947bb7881856.PNG)

Misc:
- Date and time error messages have been slightly modified.

Resolves #283 
