### PR TITLE
Auto-complete command words with TAB key

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -52,23 +52,33 @@ public class CliSyntax {
     public static final Prefix PREFIX_NOTE_START_TIME = new Prefix("st/");
     public static final Prefix PREFIX_NOTE_TITLE = new Prefix("tt/");
 
-    /* Existing command keywords (first command word)*/
+    /* Current existing command keywords (first command word)*/
     public static final List<String> FIRST_COMMAND_KEYWORDS = new ArrayList<>(Arrays.asList(
-            "course",
-            "student",
-            "module",
             "class",
+            "course",
+            "grade",
             "gradebook",
-            "note"
+            "module",
+            "note",
+            "student"
     ));
 
-    /* Existing command keywords (second command word and beyond) */
+    /* Current existing command keywords (second command word and beyond) */
     public static final List<String> SECOND_COMMAND_KEYWORDS = new ArrayList<>(Arrays.asList(
             "add",
             "addstudent",
-            "edit",
             "delete",
+            "delstudent",
+            "edit",
+            "enrol",
+            "export",
+            "find",
+            "graph",
             "list",
-            "find"
+            "listattendance",
+            "liststudents",
+            "markattendance",
+            "modattendance",
+            "view"
     ));
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.parser;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
@@ -47,4 +51,24 @@ public class CliSyntax {
     public static final Prefix PREFIX_NOTE_START_DATE = new Prefix("sd/");
     public static final Prefix PREFIX_NOTE_START_TIME = new Prefix("st/");
     public static final Prefix PREFIX_NOTE_TITLE = new Prefix("tt/");
+
+    /* Existing command keywords (first command word)*/
+    public static final List<String> FIRST_COMMAND_KEYWORDS = new ArrayList<>(Arrays.asList(
+            "course",
+            "student",
+            "module",
+            "class",
+            "gradebook",
+            "note"
+    ));
+
+    /* Existing command keywords (second command word and beyond) */
+    public static final List<String> SECOND_COMMAND_KEYWORDS = new ArrayList<>(Arrays.asList(
+            "add",
+            "addstudent",
+            "edit",
+            "delete",
+            "list",
+            "find"
+    ));
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,10 +1,16 @@
 package seedu.address.ui;
 
+import static seedu.address.logic.parser.CliSyntax.FIRST_COMMAND_KEYWORDS;
+import static seedu.address.logic.parser.CliSyntax.SECOND_COMMAND_KEYWORDS;
+
+import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
@@ -36,6 +42,33 @@ public class CommandBox extends UiPart<Region> {
         this.logic = logic;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.TAB) {
+                event.consume();
+                // System.out.println("You pressed TAB!!!");
+
+                String str = commandTextField.getText();
+                String[] commandWords = str.split("\\s+");
+
+                String lastWord = commandWords[commandWords.length - 1];
+
+                List<String> matches;
+                if (commandWords.length == 1) {
+                    matches = FIRST_COMMAND_KEYWORDS.stream()
+                            .filter(words -> words.indexOf(lastWord) == 0).collect(Collectors.toList());
+                } else {
+                    matches = SECOND_COMMAND_KEYWORDS.stream()
+                            .filter(words -> words.indexOf(lastWord) == 0).collect(Collectors.toList());
+                }
+
+                String newWord;
+                if (matches.size() == 1) {
+                    newWord = matches.get(0).replace(lastWord, "");
+                    // System.out.println(newWord);
+                    commandTextField.appendText(newWord);
+                }
+            }
+        });
         historySnapshot = logic.getHistorySnapshot();
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -70,17 +70,17 @@ public class CommandBox extends UiPart<Region> {
                         }
                     }
 
-                    List<String> matches;
+                    List<String> matches = null;
                     if (previousWords.length == 0) {
                         matches = FIRST_COMMAND_KEYWORDS.stream()
                                 .filter(words -> words.indexOf(lastWord) == 0).collect(Collectors.toList());
-                    } else {
+                    } else if (previousWords.length == 1) {
                         matches = SECOND_COMMAND_KEYWORDS.stream()
                                 .filter(words -> words.indexOf(lastWord) == 0).collect(Collectors.toList());
                     }
 
                     String wordToAppend;
-                    if (matches.size() >= 1) {
+                    if (matches != null && matches.size() >= 1) {
                         if (previousKeyPressed == KeyCode.TAB && !lastWord.isEmpty()) {
                             index = (index + 1) % matches.size();
                             wordToAppend = matches.get(index).replace(lastWord, "");


### PR DESCRIPTION
- Users will be able to auto-complete existing command words with the TAB key when typing from the command text field.
- Keywords are divided into two categories:
 First word -  contains the main feature's command words. (e.g. "course", "note")
 Second word - contains the function words. (e.g. "add", "edit")
- If more matching words are available, the user can press TAB multiple times to cycle through them.
- Currently, only the first two words from the TextField input are processed for auto-completion. This means that starting from the third word (assuming each word is separated by spaces) and beyond, there is no auto-complete function.
- Keywords can be easily added as more features are implemented.
- Auto-complete is case-sensitive as all commands are also case-sensitive.

Resolves #287 