### PR TITLE
Enhancement to Note Delete Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteDeleteCommand.java
@@ -23,14 +23,15 @@ public class NoteDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete notes. "
             + "Parameters: "
-            + "INDEX [MORE_INDEXES]..\n"
+            + "INDEX/INDEX_RANGE [MORE_INDEXES]..\n"
             + "Example: " + COMMAND_WORD + " "
-            + "2 4 3";
+            + "2-4 7 6";
 
-    public static final String MESSAGE_SUCCESS = "(%s) note(s) successfully deleted.";
+    public static final String MESSAGE_SUCCESS = "%s note(s) successfully deleted.";
     public static final String MESSAGE_INVALID_INDEX = "Invalid input! INDEX is out of bounds.";
-    public static final String MESSAGE_PARSE_INDEX_ERROR = "You entered an invalid index. "
-            + "Please enter positive integers only.";
+    public static final String MESSAGE_PARSE_INDEX_ERROR = "Invalid index! Please ensure the following:\n"
+            + "- INDEX is a positive integer\n"
+            + "- INDEX_RANGE has the lower bound INDEX smaller than the upper bound INDEX.";
 
     public static final String MESSAGE_NOTE_PAGE_NOT_LOADED = "The command has been blocked by the system.\n"
             + "Please call the command to list notes before calling this command again "

--- a/src/main/java/seedu/address/logic/commands/NoteFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteFindCommand.java
@@ -78,7 +78,6 @@ public class NoteFindCommand extends Command {
         }
         sb.append(REGEX_CLOSER);
 
-        System.out.println(sb.toString());
         return sb.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/NoteDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteDeleteCommandParser.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.NoteDeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -15,6 +17,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new NoteDeleteCommand object
  */
 public class NoteDeleteCommandParser implements Parser<NoteDeleteCommand> {
+
+    private static final Pattern NUMBER_RANGE_REGEX = Pattern.compile("^(?<from>-?[0-9]+)-(?<to>-?[0-9]+)$");
     /**
      * Parses the given {@code String} of arguments in the context of the NoteDeleteCommand
      * and returns a NoteDeleteCommand object for execution.
@@ -30,15 +34,33 @@ public class NoteDeleteCommandParser implements Parser<NoteDeleteCommand> {
         List<Integer> indexList = new ArrayList<>();
 
         for (String indexAsString : indexListString) {
-            try {
-                Integer num = Integer.parseInt(indexAsString.trim());
-                if (num > 0) {
-                    indexList.add(num);
-                } else {
+            Matcher matcher = NUMBER_RANGE_REGEX.matcher(indexAsString);
+            if (matcher.matches()) {
+                int lowerIndex = Integer.parseInt(matcher.group("from"));
+                int upperIndex = Integer.parseInt(matcher.group("to"));
+
+                if (lowerIndex >= upperIndex) {
                     throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
                 }
-            } catch (NumberFormatException e) {
-                throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
+
+                for (int i = lowerIndex; i <= upperIndex; i++) {
+                    if (i > 0) {
+                        indexList.add(i);
+                    } else {
+                        throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
+                    }
+                }
+            } else {
+                try {
+                    Integer num = Integer.parseInt(indexAsString.trim());
+                    if (num > 0) {
+                        indexList.add(num);
+                    } else {
+                        throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
+                }
             }
         }
 
@@ -48,10 +70,6 @@ public class NoteDeleteCommandParser implements Parser<NoteDeleteCommand> {
             throw new ParseException(NoteDeleteCommand.MESSAGE_DUPLICATE_INDEX_FOUND);
         } else {
             indexList.sort(Collections.reverseOrder());
-        }
-
-        for (Integer i : indexList) {
-            System.out.println(i.toString());
         }
 
         return new NoteDeleteCommand(indexList);

--- a/src/main/java/seedu/address/logic/parser/NoteDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteDeleteCommandParser.java
@@ -39,16 +39,12 @@ public class NoteDeleteCommandParser implements Parser<NoteDeleteCommand> {
                 int lowerIndex = Integer.parseInt(matcher.group("from"));
                 int upperIndex = Integer.parseInt(matcher.group("to"));
 
-                if (lowerIndex >= upperIndex) {
+                if (lowerIndex >= upperIndex || lowerIndex <= 0) {
                     throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
                 }
 
                 for (int i = lowerIndex; i <= upperIndex; i++) {
-                    if (i > 0) {
-                        indexList.add(i);
-                    } else {
-                        throw new ParseException(NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR);
-                    }
+                    indexList.add(i);
                 }
             } else {
                 try {

--- a/src/test/java/seedu/address/logic/commands/NoteFindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteFindCommandTest.java
@@ -26,9 +26,6 @@ public class NoteFindCommandTest {
 
     private static NoteManager noteManager = NoteManager.getInstance();
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     private NoteBuilder note1 = new NoteBuilder();
 
     @Before

--- a/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_TIME;
@@ -79,66 +81,93 @@ public class NoteAddCommandParserTest {
     public void parse_invalidDateTimeFormat_throwsParseException() throws ParseException {
         String expectedMessageInvalidDate = Messages.MESSAGE_INVALID_DATE_FORMAT;
         String expectedMessageInvalidTime = Messages.MESSAGE_INVALID_TIME_FORMAT;
+        String expectedMessageBlankField = Messages.MESSAGE_BLANK_FIELD;
 
-        // unrecognized date format for start date
-        String args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "21 September 2013 ";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidDate);
-        parser.parse(args);
+        String args;
 
-        // unrecognized time format for start time
-        args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "21/1/2013 "
-                + PREFIX_NOTE_START_TIME + "23:59";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidTime);
-        parser.parse(args);
+        try {
+            // args contain prefix with blank value
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE;
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageBlankField, e.getMessage());
+        }
 
-        // unrecognized date format for end date
-        args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "1/1/2018 "
-                + PREFIX_NOTE_END_DATE + "2018-10-12";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidDate);
-        parser.parse(args);
+        try {
+            // unrecognized date format for start date
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "21 September 2013";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains(expectedMessageInvalidDate));
+        }
 
-        // unrecognized time format for end time
-        args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "1.1.2013 "
-                + PREFIX_NOTE_START_TIME + "11:00 AM "
-                + PREFIX_NOTE_END_TIME + "1:00PM";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidTime);
-        parser.parse(args);
+        try {
+            // unrecognized time format for start time
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "21/1/2013 "
+                    + PREFIX_NOTE_START_TIME + "23:59";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains(expectedMessageInvalidTime));
+        }
+
+        try {
+            // unrecognized date format for end date
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "1/1/2018 "
+                    + PREFIX_NOTE_END_DATE + "2018-10-12";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains(expectedMessageInvalidDate));
+        }
+
+        try {
+            // unrecognized time format for end time, no space separation between the time and period(AM/PM)
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "1.1.2013 "
+                    + PREFIX_NOTE_START_TIME + "11:00 AM "
+                    + PREFIX_NOTE_END_TIME + "1:00PM";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains(expectedMessageInvalidTime));
+        }
+
     }
 
     @Test
     public void parse_invalidDateTimeDifference_throwsParseException() throws ParseException {
         String expectedMessage = NoteAddCommandParser.MESSAGE_INVALID_DATE_TIME_DIFFERENCE;
 
-        // end date is earlier than start date
-        String args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "20-12-2012 "
-                + PREFIX_NOTE_END_DATE + "19-12-2012";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessage);
-        parser.parse(args);
+        String args;
+        try {
+            // end date is earlier than start date
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "20-12-2012 "
+                    + PREFIX_NOTE_END_DATE + "19-12-2012";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        }
 
-        // omitting end date sets its date similar to start date, hence, end date is earlier than start date
-        args = " "
-                + PREFIX_MODULE_CODE + "CS2113 "
-                + PREFIX_NOTE_START_DATE + "20-12-2012 "
-                + PREFIX_NOTE_START_TIME + "9:01 PM "
-                + PREFIX_NOTE_END_TIME + "9:00 PM";
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessage);
-        parser.parse(args);
+        try {
+            // omitting end date sets its date similar to start date, hence, end date is earlier than start date
+            args = " "
+                    + PREFIX_MODULE_CODE + "CS2113 "
+                    + PREFIX_NOTE_START_DATE + "20-12-2012 "
+                    + PREFIX_NOTE_START_TIME + "9:01 PM "
+                    + PREFIX_NOTE_END_TIME + "9:00 PM";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteAddCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_END_TIME;
@@ -91,6 +92,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_MODULE_CODE + "CS2113 "
                     + PREFIX_NOTE_START_DATE;
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageBlankField, e.getMessage());
         }
@@ -101,6 +103,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_MODULE_CODE + "CS2113 "
                     + PREFIX_NOTE_START_DATE + "21 September 2013";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertTrue(e.getMessage().contains(expectedMessageInvalidDate));
         }
@@ -112,6 +115,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_NOTE_START_DATE + "21/1/2013 "
                     + PREFIX_NOTE_START_TIME + "23:59";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertTrue(e.getMessage().contains(expectedMessageInvalidTime));
         }
@@ -123,6 +127,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_NOTE_START_DATE + "1/1/2018 "
                     + PREFIX_NOTE_END_DATE + "2018-10-12";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertTrue(e.getMessage().contains(expectedMessageInvalidDate));
         }
@@ -135,6 +140,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_NOTE_START_TIME + "11:00 AM "
                     + PREFIX_NOTE_END_TIME + "1:00PM";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertTrue(e.getMessage().contains(expectedMessageInvalidTime));
         }
@@ -153,6 +159,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_NOTE_START_DATE + "20-12-2012 "
                     + PREFIX_NOTE_END_DATE + "19-12-2012";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessage, e.getMessage());
         }
@@ -165,6 +172,7 @@ public class NoteAddCommandParserTest {
                     + PREFIX_NOTE_START_TIME + "9:01 PM "
                     + PREFIX_NOTE_END_TIME + "9:00 PM";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessage, e.getMessage());
         }

--- a/src/test/java/seedu/address/logic/parser/NoteDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteDeleteCommandParserTest.java
@@ -2,25 +2,15 @@ package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.containsString;
+import static org.junit.Assert.fail;
 
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.NoteDeleteCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.ModelManager;
-import seedu.address.model.StorageController;
-import seedu.address.model.note.NoteManager;
-import seedu.address.testutil.NoteBuilder;
 
 /**
  * Contains tests for NoteDeleteCommandParser.
@@ -43,6 +33,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, contains non-numeric input
             args = " 15 this is an 2invalid input";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageIndexError, e.getMessage());
         }
@@ -51,6 +42,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, input contains a non-positive integer
             args = "3 4 0";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageIndexError, e.getMessage());
         }
@@ -59,6 +51,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, index range has lower bound > upper bound
             args = "3-2";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageIndexError, e.getMessage());
         }
@@ -67,6 +60,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, index range has lower bound = upper bound
             args = "2-2";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageIndexError, e.getMessage());
         }
@@ -75,6 +69,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, index range contains a non-positive integer
             args = "-2-3";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageIndexError, e.getMessage());
         }
@@ -83,6 +78,7 @@ public class NoteDeleteCommandParserTest {
             // invalid args, duplicate index exists
             args = "1 2-4 3";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageDuplicate, e.getMessage());
         }

--- a/src/test/java/seedu/address/logic/parser/NoteDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteDeleteCommandParserTest.java
@@ -2,11 +2,14 @@ package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
 
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.CommandHistory;
@@ -27,49 +30,82 @@ public class NoteDeleteCommandParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private static NoteManager noteManager = NoteManager.getInstance();
     private NoteDeleteCommandParser parser = new NoteDeleteCommandParser();
-
-
-    @Before
-    public void setUp() {
-        StorageController.enterTestMode();
-        noteManager.clearNotes();
-        noteManager.saveNoteList();
-    }
 
     @Test
     public void parse_invalidArgs_throwsParseException() throws ParseException {
-        String expectedMessage = NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR;
+        String expectedMessageIndexError = NoteDeleteCommand.MESSAGE_PARSE_INDEX_ERROR;
+        String expectedMessageDuplicate = NoteDeleteCommand.MESSAGE_DUPLICATE_INDEX_FOUND;
 
-        // invalid args
-        String args = " 15 this is an 2invalid input";
+        String args;
 
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessage);
+        try {
+            // invalid args, contains non-numeric input
+            args = " 15 this is an 2invalid input";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageIndexError, e.getMessage());
+        }
 
-        parser.parse(args);
+        try {
+            // invalid args, input contains a non-positive integer
+            args = "3 4 0";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageIndexError, e.getMessage());
+        }
+
+        try {
+            // invalid args, index range has lower bound > upper bound
+            args = "3-2";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageIndexError, e.getMessage());
+        }
+
+        try {
+            // invalid args, index range has lower bound = upper bound
+            args = "2-2";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageIndexError, e.getMessage());
+        }
+
+        try {
+            // invalid args, index range contains a non-positive integer
+            args = "-2-3";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageIndexError, e.getMessage());
+        }
+
+        try {
+            // invalid args, duplicate index exists
+            args = "1 2-4 3";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageDuplicate, e.getMessage());
+        }
     }
 
     @Test
     public void parse_argsIsNumeric_success() throws ParseException, CommandException {
-        noteManager.addNote(new NoteBuilder().build());
-        noteManager.saveNoteList();
-        String expectedMessage = NoteDeleteCommand.MESSAGE_SUCCESS;
-
         // valid args
         String args = "  1  ";
 
         NoteDeleteCommand noteDeleteCommand = parser.parse(args);
-        CommandResult result = noteDeleteCommand.execute(new ModelManager(), new CommandHistory());
+        assertNotNull(noteDeleteCommand);
 
-        assertNotNull(result);
-        assertEquals(expectedMessage, NoteDeleteCommand.MESSAGE_SUCCESS);
-    }
+        // valid args, index range
+        args = "2-4";
+        noteDeleteCommand = null;
+        noteDeleteCommand = parser.parse(args);
+        assertNotNull(noteDeleteCommand);
 
-    @AfterClass
-    public static void tearDown() {
-        noteManager.clearNotes();
-        noteManager.saveNoteList();
+        // valid args, single index combined with range of indexes
+        args = "2-4 6";
+        noteDeleteCommand = null;
+        noteDeleteCommand = parser.parse(args);
+        assertNotNull(noteDeleteCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/NoteFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteFindCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_KEY_WORD;
 
 import org.junit.AfterClass;
@@ -48,6 +49,7 @@ public class NoteFindCommandParserTest {
             // invalid args, empty
             args = "";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageInvalidCommand, e.getMessage());
         }
@@ -56,6 +58,7 @@ public class NoteFindCommandParserTest {
             // invalid args with prefix but blank param
             args = " " + PREFIX_NOTE_KEY_WORD;
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageInvalidKeyword, e.getMessage());
         }
@@ -64,6 +67,7 @@ public class NoteFindCommandParserTest {
             // invalid args with prefix but contain multiple words separated by space
             args = " " + PREFIX_NOTE_KEY_WORD + "hello world";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageInvalidKeyword, e.getMessage());
         }

--- a/src/test/java/seedu/address/logic/parser/NoteFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteFindCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_KEY_WORD;
 
@@ -41,22 +42,31 @@ public class NoteFindCommandParserTest {
 
         String expectedMessageInvalidKeyword = NoteFindCommand.MESSAGE_INVALID_KEYWORD;
 
-        // invalid args, empty
-        String args = "";
+        String args;
 
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidCommand);
-        parser.parse(args);
+        try {
+            // invalid args, empty
+            args = "";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageInvalidCommand, e.getMessage());
+        }
 
-        // invalid args with prefix but blank param
-        args = " " + PREFIX_NOTE_KEY_WORD;
+        try {
+            // invalid args with prefix but blank param
+            args = " " + PREFIX_NOTE_KEY_WORD;
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageInvalidKeyword, e.getMessage());
+        }
 
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidKeyword);
-        parser.parse(args);
-
-        // invalid args with prefix but contains a space in between
-        args = " " + PREFIX_NOTE_KEY_WORD + "hello world";
+        try {
+            // invalid args with prefix but contain multiple words separated by space
+            args = " " + PREFIX_NOTE_KEY_WORD + "hello world";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageInvalidKeyword, e.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 
 import org.junit.AfterClass;
@@ -47,14 +48,16 @@ public class NoteListCommandParserTest {
             // invalid args, missing prefix
             args = " CS2113";
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageInvalidCommand, e.getMessage());
         }
 
         try {
-            // invalid args, with prefix but has empty param
+            // invalid args, with prefix but blank param
             args = " " + PREFIX_MODULE_CODE;
             parser.parse(args);
+            fail("Exception not thrown");
         } catch (ParseException e) {
             assertEquals(expectedMessageEmptyModuleCodeArg, e.getMessage());
         }

--- a/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteListCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 
@@ -40,19 +41,23 @@ public class NoteListCommandParserTest {
                 Messages.MESSAGE_INVALID_COMMAND_FORMAT, NoteListCommand.MESSAGE_USAGE);
         String expectedMessageEmptyModuleCodeArg = NoteListCommand.MESSAGE_EMPTY_MODULE_CODE_ARG;
 
-        // invalid args, missing prefix
-        String args = " CS2113";
+        String args;
 
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageInvalidCommand);
-        parser.parse(args);
+        try {
+            // invalid args, missing prefix
+            args = " CS2113";
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageInvalidCommand, e.getMessage());
+        }
 
-        // invalid args, with prefix but has empty param
-        args = " " + PREFIX_MODULE_CODE;
-
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(expectedMessageEmptyModuleCodeArg);
-        parser.parse(args);
+        try {
+            // invalid args, with prefix but has empty param
+            args = " " + PREFIX_MODULE_CODE;
+            parser.parse(args);
+        } catch (ParseException e) {
+            assertEquals(expectedMessageEmptyModuleCodeArg, e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
- `note delete` can accept range of INDEXES as input for bulk deleting.
 e.g. `note delete 2-5`
 The command above deletes notes with index 2, 3, 4, and 5 from the current list.

- Updated test codes accordingly.
- Minor changes to other test codes.